### PR TITLE
Support tagged releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ to your `composer.json` file:
 ```json
 {
     "require": {
-        "alfaproject/omnipay-skrill": "dev-master"
+        "qobo/omnipay-skrill": "^2.0"
     }
 }
 ```

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "alfaproject/omnipay-skrill",
+    "name": "qobo/omnipay-skrill",
     "type": "library",
     "description": "Skrill driver for the Omnipay payment processing library",
     "keywords": [
@@ -29,10 +29,5 @@
     "require-dev": {
         "omnipay/tests": "~2.0",
         "satooshi/php-coveralls": "dev-master"
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "2.0.x-dev"
-        }
     }
 }


### PR DESCRIPTION
Our minimum required stability does not allow for branch versions,
therefor we forked, changed `composer.json` and `README.md` files
to support our own tagged releases.